### PR TITLE
Updating README with copy of NCML out

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ To reactivate, the following needs to be typed::
 
 To use PyNEMO, the following command is entered: (the example will run an benchmarking test)::
 
+    $ cp /path/to/PyNEMO/pynemo/output_NCML/* /path/to/ncml_out/ -r
     $ pynemo -s /path/to/namelist/file (e.g. PyNEMO/inputs/namelist_remote.bdy)
 
 Other commands include -d which downloads the specified CMEMS data in the namelist bdy file.::


### PR DESCRIPTION
Copying `output_NCML` into a folder is a necessary step in order to run `pynemo` and adding a step in the README helps figuring out the missing data.

I had trouble figuring it out on my own, so in case it can help out others...