### PR TITLE
227 ice variables

### DIFF
--- a/src/pybdy/nemo_bdy_extr_tm3.py
+++ b/src/pybdy/nemo_bdy_extr_tm3.py
@@ -1266,6 +1266,7 @@ class Extract:
             unit_origin,
             self.settings["fv"],
             self.settings["dst_calendar"],
+            self.settings["ice"],
             self.g_type.upper(),
         )
 

--- a/src/pybdy/nemo_bdy_ncgen.py
+++ b/src/pybdy/nemo_bdy_ncgen.py
@@ -25,7 +25,7 @@ from netCDF4 import Dataset
 
 
 def CreateBDYNetcdfFile(
-    filename, xb_len, x_len, y_len, depth_len, rw, h, orig, fv, calendar, grd
+    filename, xb_len, x_len, y_len, depth_len, rw, h, orig, fv, calendar, ln_ice, grd
 ):
     """Create a template of bdy netcdf files. A common for T, I, U, V, E grid types."""
     gridNames = ["T", "I", "U", "V", "E", "Z"]  # All possible grids
@@ -181,9 +181,9 @@ def CreateBDYNetcdfFile(
             ),
             fill_value=fv,
         )
-        if grd == "I":
+        if ln_ice | (grd == "I"):
             varildID = ncid.createVariable(
-                "ileadfra",
+                "ice1",
                 "f4",
                 (
                     "time_counter",
@@ -193,7 +193,7 @@ def CreateBDYNetcdfFile(
                 fill_value=fv,
             )
             variicID = ncid.createVariable(
-                "iicethic",
+                "ice2",
                 "f4",
                 (
                     "time_counter",
@@ -203,7 +203,7 @@ def CreateBDYNetcdfFile(
                 fill_value=fv,
             )
             varisnID = ncid.createVariable(
-                "isnowthi",
+                "ice3",
                 "f4",
                 (
                     "time_counter",
@@ -440,19 +440,19 @@ def CreateBDYNetcdfFile(
         varsalID.long_name = "Salinity"
         varsalID.grid = "bdyT"
 
-        if grd == "I":
+        if ln_ice | (grd == "I"):
             varildID.units = "%"
-            varildID.short_name = "ildsconc"
-            varildID.long_name = "Ice lead fraction"
+            varildID.short_name = "siconc"
+            varildID.long_name = "Sea ice fraction"
             varildID.grid = "bdyT"
 
             variicID.units = "m"
-            variicID.short_name = "iicethic"
-            variicID.long_name = "Ice thickness"
+            variicID.short_name = "sivolu"
+            variicID.long_name = "Sea ice volume"
             variicID.grid = "bdyT"
 
             varisnID.units = "m"
-            varisnID.short_name = "isnowthi"
+            varisnID.short_name = "snthic"
             varisnID.long_name = "Snow thickness"
             varisnID.grid = "bdyT"
     elif grd == "U":

--- a/src/pybdy/nemo_bdy_ncpop.py
+++ b/src/pybdy/nemo_bdy_ncpop.py
@@ -40,9 +40,9 @@ def write_data_to_file(filename, variable_name, data):
         "sossheig",
         "vobtcrtx",
         "vobtcrty",
-        "siconc",
-        "sivolu",
-        "snthic",
+        "ice1",
+        "ice2",
+        "ice3",
     ]
     # print(filename)
     # print(variable_name)

--- a/tests/data/namelist_zz_end_to_end.bdy
+++ b/tests/data/namelist_zz_end_to_end.bdy
@@ -54,7 +54,7 @@
     ln_dyn3d       = .false.              !  boundary conditions for
                                           !  baroclinic velocities
     ln_tra         = .true.               !  boundary conditions for T and S
-    ln_ice         = .false.              !  ice boundary condition
+    ln_ice         = .true.              !  ice boundary condition
     ln_zinterp     = .true.               !  vertical interpolation
     nn_rimwidth    = 9                    !  width of the relaxation zone
 

--- a/tests/synth/synth_bathymetry.py
+++ b/tests/synth/synth_bathymetry.py
@@ -455,6 +455,9 @@ def generate_variables(
     uvel = xr.full_like(ds_domcfg.gdept, 1.0, dtype=np.double)
     vvel = xr.full_like(ds_domcfg.gdept, 1.0, dtype=np.double)
     ssh = xr.full_like(ds_domcfg.Bathymetry, 0.0, dtype=np.double)
+    ice1 = xr.full_like(ds_domcfg.Bathymetry, 0.0, dtype=np.double)
+    ice2 = xr.full_like(ds_domcfg.Bathymetry, 0.0, dtype=np.double)
+    ice3 = xr.full_like(ds_domcfg.Bathymetry, 0.0, dtype=np.double)
 
     # Add attributes
     temp.attrs = dict(units="C", long_name="Temperature (degrees centigrade)")
@@ -462,6 +465,9 @@ def generate_variables(
     uvel.attrs = dict(units="m/s", long_name="Zonal Velocity (m/s)")
     vvel.attrs = dict(units="m/s", long_name="Meridional Velocity (m/s)")
     ssh.attrs = dict(units="m", long_name="Sea Surface Height (m)")
+    ice1.attrs = dict(units="", long_name="Sea ice area fraction")
+    ice2.attrs = dict(units="m3", long_name="Sea ice volume (m3)")
+    ice3.attrs = dict(units="m", long_name="Snow thickness (m)")
 
     # Add to ds
     ds["votemper"] = temp
@@ -469,6 +475,9 @@ def generate_variables(
     ds["vozocrtx"] = uvel
     ds["vomecrty"] = vvel
     ds["sossheig"] = ssh
+    ds["ice1"] = ice1
+    ds["ice2"] = ice2
+    ds["ice3"] = ice3
 
     # Add t dim
     # times = pd.date_range("2020","2023",freq='Y')+ DateOffset(months=6)

--- a/tests/test_zz_end_to_end.py
+++ b/tests/test_zz_end_to_end.py
@@ -96,7 +96,7 @@ def test_zco_zco():
     print(summary_grid)
     test_grid = {
         "Num_var_co": 21,
-        "Num_var_t": 11,
+        "Num_var_t": 14,
         "Min_gdept": 41.66666793823242,
         "Max_gdept": 958.3333129882812,
         "Shape_temp": (30, 25, 1, 1584),
@@ -176,7 +176,7 @@ def test_zps_sco():
     print(summary_grid)
     test_grid = {
         "Num_var_co": 21,
-        "Num_var_t": 11,
+        "Num_var_t": 14,
         "Min_gdept": 3.8946874141693115,
         "Max_gdept": 966.4112548828125,
         "Shape_temp": (30, 15, 1, 1584),
@@ -256,7 +256,7 @@ def test_sco_sco():
     print(summary_grid)
     test_grid = {
         "Num_var_co": 21,
-        "Num_var_t": 11,
+        "Num_var_t": 14,
         "Min_gdept": 3.8946874141693115,
         "Max_gdept": 966.4112548828125,
         "Shape_temp": (30, 15, 1, 1584),
@@ -336,7 +336,7 @@ def test_sco_zco():
     print(summary_grid)
     test_grid = {
         "Num_var_co": 21,
-        "Num_var_t": 11,
+        "Num_var_t": 14,
         "Min_gdept": 41.66666793823242,
         "Max_gdept": 958.3333129882812,
         "Shape_temp": (30, 25, 1, 1584),
@@ -419,7 +419,7 @@ def test_wrap_sc():
     print(summary_grid)
     test_grid = {
         "Num_var_co": 21,
-        "Num_var_t": 11,
+        "Num_var_t": 14,
         "Min_gdept": 41.66666793823242,
         "Max_gdept": 958.3333129882812,
         "Shape_temp": (30, 25, 1, 1584),


### PR DESCRIPTION
This fixes #227. The ice variable names have been made consistent with ice1 ice2, ice3 and get created in netcdf now because ln_ice is passed across to the create Netcdf function nemo_bdy_ncgen.py. Before we were relying on and "I" grid.

The end-to-end tests have been updated to include ice variables.